### PR TITLE
Change lower pixel size of the first breakpoint

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -276,7 +276,7 @@ h1 {
   margin-top: 30px;
 }
 
-@media (max-width: 1900px) {
+@media (max-width: 1700px) {
 section {
   grid-template-columns: repeat(2, 1fr);
   width: 70%;


### PR DESCRIPTION
This is a pull Request I made after publishing the page because the published page and the page preview looked different and the breakpoints were inaccurate to the experience itself.